### PR TITLE
Release 1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To use this module in your Maven project, please add following configuration to 
       <plugin>
         <groupId>jp.skypencil.guava</groupId>
         <artifactId>spotbugs-plugin</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
       </plugin>
     </plugins>
   </configuration>
@@ -55,7 +55,7 @@ To use this module in your Maven project, please add following configuration to 
 <dependency>
   <groupId>jp.skypencil.guava</groupId>
   <artifactId>helper</artifactId>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
 </dependency>
 ```
 

--- a/helper/pom.xml
+++ b/helper/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>jp.skypencil.guava</groupId>
     <artifactId>guava-helper-for-java-8</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5-SNAPSHOT</version>
   </parent>
   <artifactId>helper</artifactId>
   <name>Helper for Guava on Java8</name>

--- a/helper/pom.xml
+++ b/helper/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>jp.skypencil.guava</groupId>
     <artifactId>guava-helper-for-java-8</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.0.4</version>
   </parent>
   <artifactId>helper</artifactId>
   <name>Helper for Guava on Java8</name>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>jp.skypencil.guava</groupId>
   <artifactId>guava-helper-for-java-8</artifactId>
-  <version>1.0.4</version>
+  <version>1.0.5-SNAPSHOT</version>
   <url>https://github.com/KengoTODA/guava-helper-for-java-8</url>
   <name>Guava Helper for Java 8</name>
   <description>A tool set to help developer to use Guava with Java 8</description>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>jp.skypencil.guava</groupId>
   <artifactId>guava-helper-for-java-8</artifactId>
-  <version>1.0.4-SNAPSHOT</version>
+  <version>1.0.4</version>
   <url>https://github.com/KengoTODA/guava-helper-for-java-8</url>
   <name>Guava Helper for Java 8</name>
   <description>A tool set to help developer to use Guava with Java 8</description>

--- a/sonarqube-plugin/pom.xml
+++ b/sonarqube-plugin/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>jp.skypencil.guava</groupId>
     <artifactId>guava-helper-for-java-8</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.0.4</version>
   </parent>
   <artifactId>guava-helper-sonarqube-plugin</artifactId>
   <name>SonarQube plugin</name>

--- a/sonarqube-plugin/pom.xml
+++ b/sonarqube-plugin/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>jp.skypencil.guava</groupId>
     <artifactId>guava-helper-for-java-8</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5-SNAPSHOT</version>
   </parent>
   <artifactId>guava-helper-sonarqube-plugin</artifactId>
   <name>SonarQube plugin</name>

--- a/sonarqube-plugin/pom.xml
+++ b/sonarqube-plugin/pom.xml
@@ -17,8 +17,8 @@
         <version>1.18.0.372</version>
         <extensions>true</extensions>
         <configuration>
-          <pluginKey>guava</pluginKey>
-          <pluginName>Guava Helper</pluginName>
+          <pluginKey>guavamigration</pluginKey>
+          <pluginName>Guava Migration Helper</pluginName>
           <pluginDescription><![CDATA[Support migration from Guava to Java8]]></pluginDescription>
           <pluginClass>jp.skypencil.guava.SonarQubePlugin</pluginClass>
           <useChildFirstClassLoader>false</useChildFirstClassLoader>

--- a/spotbugs-plugin/pom.xml
+++ b/spotbugs-plugin/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>jp.skypencil.guava</groupId>
     <artifactId>guava-helper-for-java-8</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.0.4</version>
   </parent>
   <artifactId>spotbugs-plugin</artifactId>
   <name>SpotBugs plugin</name>

--- a/spotbugs-plugin/pom.xml
+++ b/spotbugs-plugin/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>jp.skypencil.guava</groupId>
     <artifactId>guava-helper-for-java-8</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5-SNAPSHOT</version>
   </parent>
   <artifactId>spotbugs-plugin</artifactId>
   <name>SpotBugs plugin</name>


### PR DESCRIPTION
According to review result at SonarSource forum, it's better to replace key with non-generic key.

https://community.sonarsource.com/t/request-to-deploy-to-the-marketplace-guava-helper-for-java-8/507