### PR TITLE
make sure SonarQube plugin works with SonarQube LTS & latest sonar-java

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ To use this module in your Maven project, please add following configuration to 
 </dependency>
 ```
 
+SonarQube plugin
+----------------
+
+See [sonarqube/README.md](sonarqube/README.md) for detail.
+
 Change set
 ----------
 

--- a/sonarqube-plugin/Dockerfile
+++ b/sonarqube-plugin/Dockerfile
@@ -1,0 +1,8 @@
+FROM sonarqube:6.7.4-alpine
+
+ENV SONAR_JAVA_VERSION=5.1.0.13090 \
+    SONAR_FINDBUGS_VERSION=3.5.0
+
+RUN wget -O $SONARQUBE_HOME/extensions/plugins/sonar-findbugs-plugin-$SONAR_FINDBUGS_VERSION.jar --no-verbose https://github.com/spotbugs/sonar-findbugs/releases/download/$SONAR_FINDBUGS_VERSION/sonar-findbugs-plugin.jar && \
+    wget -O $SONARQUBE_HOME/extensions/plugins/sonar-java-plugin-$SONAR_JAVA_VERSION.jar --no-verbose http://central.maven.org/maven2/org/sonarsource/java/sonar-java-plugin/$SONAR_JAVA_VERSION/sonar-java-plugin-$SONAR_JAVA_VERSION.jar
+COPY target/guava-helper-sonarqube-plugin-1.0.5-SNAPSHOT.jar $SONARQUBE_HOME/extensions/plugins/

--- a/sonarqube-plugin/README.md
+++ b/sonarqube-plugin/README.md
@@ -1,0 +1,19 @@
+# Guava Migration Helper SonarQube Plugin
+
+## Compatibility
+
+|Guava Migration Helper Version|SonarQube Version|SonarJava Version|sonar-findbugs Version|
+|----|----|----|----|
+|v1.0.5|v6.7.4|v5.1.0.13090|v3.5|
+|v1.0.4|v5.6.6|v4.0|v3.5|
+
+## How to test
+
+This project provides a `Dockerfile` to launch SonarQube with necessary plugins, please run following commands then you can visit SonarQube at http://localhost:9000/
+
+```sh
+$ docker build -t sonarqube-with-plugin .
+$ docker run -it -p 9000:9000 -p 9092:9092 sonarqube-with-plugin
+```
+
+For test, please do not forget to enable rules in your quality profile.

--- a/sonarqube-plugin/pom.xml
+++ b/sonarqube-plugin/pom.xml
@@ -21,7 +21,6 @@
           <pluginName>Guava Migration Helper</pluginName>
           <pluginDescription><![CDATA[Support migration from Guava to Java8]]></pluginDescription>
           <pluginClass>jp.skypencil.guava.SonarQubePlugin</pluginClass>
-          <useChildFirstClassLoader>false</useChildFirstClassLoader>
           <basePlugin>findbugs</basePlugin>
           <requirePlugins>findbugs:3.5</requirePlugins><!-- the version introduced SpotBugs 3.1 -->
           <pluginUrl>https://github.com/KengoTODA/guava-helper-for-java-8</pluginUrl>
@@ -75,17 +74,23 @@
       <groupId>jp.skypencil.guava</groupId>
       <artifactId>spotbugs-plugin</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-plugin-api</artifactId>
-      <version>5.6.6</version><!-- LTS release that is used by sonar-findbugs 3.5 -->
+      <version>6.7.4</version><!-- Latest LTS release -->
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.sonarsource.java</groupId>
       <artifactId>sonar-java-plugin</artifactId>
-      <version>4.0</version><!-- used by sonar-findbugs 3.5 -->
+      <version>5.1.0.13090</version><!-- used by sonar-findbugs 3.7 -->
       <scope>provided</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
According to [the review from SonarSource](https://community.sonarsource.com/t/request-to-deploy-to-the-marketplace-guava-helper-for-java-8/507/10?u=kengotoda), SonarQube LTS is now 6.7. It is also necessary to support latest sonar-java.